### PR TITLE
Fix issue related to Boolean type usage in a request body

### DIFF
--- a/lib/sisense/api/client.rb
+++ b/lib/sisense/api/client.rb
@@ -109,7 +109,7 @@ module Sisense
           return object.map { |item| parameterize(item) } if object.is_a?(Array)
 
           obj.keys.each do |key|
-            obj[key] = parameterize_object(obj[key]) unless obj[key].is_a?(String)
+            obj[key] = parameterize_object(obj[key])
             obj[key.to_s.to_camel_case] = obj.delete(key)
           end
         end
@@ -119,6 +119,8 @@ module Sisense
         return parameterize(object.to_h) if Sisense::API::Resource.descendants.include?(object.class)
         return parameterize(object) if object.is_a?(Hash)
         return object.map { |item| item.is_a?(String) ? item : parameterize_object(item) } if object.is_a?(Array)
+
+        object
       end
     end
   end


### PR DESCRIPTION
I open this PR in order to fix an unexpected behaviour of the `parameterize` method.
I've been able to replicate the bug locally and returning the given object as the fallback result of `parameterize_object` method fixed the issue.
Also I removed the `String` check condition since it doesn't have any incidence on the process with that new method fallback.

![Screen Shot 2020-01-31 at 5 55 09 PM](https://user-images.githubusercontent.com/112219/73580795-e6e60f80-4454-11ea-91fe-2d0bbb9ec041.png)

Thanks @kcarmonamurphy for raising that point, good catch 👍 

Fixes #6 