### PR TITLE
Get rid of parameterize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+tags
 
 # rspec failure tracking
 .rspec_status

--- a/lib/sisense/api/client.rb
+++ b/lib/sisense/api/client.rb
@@ -67,7 +67,7 @@ module Sisense
           request = VERB_MAP[method].new(encode_path(path, params), headers)
         else
           request = VERB_MAP[method].new(encode_path(path), headers)
-          request.body = parameterize(params).to_json
+          request.body = params.to_json
         end
         handle_response(http.request(request))
       end
@@ -102,25 +102,6 @@ module Sisense
 
       def headers
         @headers ||= { 'Authorization' => "Bearer #{Sisense.access_token}", 'Content-Type' => 'application/json' }
-      end
-
-      def parameterize(object)
-        object.tap do |obj|
-          return object.map { |item| parameterize(item) } if object.is_a?(Array)
-
-          obj.keys.each do |key|
-            obj[key] = parameterize_object(obj[key]) unless obj[key].is_a?(String)
-            obj[key.to_s.to_camel_case] = obj.delete(key)
-          end if obj.respond_to?(:keys)
-
-          obj
-        end
-      end
-
-      def parameterize_object(object)
-        return parameterize(object.to_h) if Sisense::API::Resource.descendants.include?(object.class)
-        return parameterize(object) if object.is_a?(Hash)
-        return object.map { |item| item.is_a?(String) ? item : parameterize_object(item) } if object.is_a?(Array)
       end
     end
   end

--- a/lib/sisense/api/client.rb
+++ b/lib/sisense/api/client.rb
@@ -67,7 +67,8 @@ module Sisense
           request = VERB_MAP[method].new(encode_path(path, params), headers)
         else
           request = VERB_MAP[method].new(encode_path(path), headers)
-          request.body = params.to_json
+          binding.pry
+          request.body = parameterize(params).to_json
         end
         handle_response(http.request(request))
       end
@@ -102,6 +103,25 @@ module Sisense
 
       def headers
         @headers ||= { 'Authorization' => "Bearer #{Sisense.access_token}", 'Content-Type' => 'application/json' }
+      end
+
+      def parameterize(object)
+        object.tap do |obj|
+          return object.map { |item| parameterize(item) } if object.is_a?(Array)
+
+          obj.keys.each do |key|
+            obj[key] = parameterize_object(obj[key]) unless (obj[key].is_a?(String) or [true, false].include?(obj[key]))
+            obj[key.to_s.to_camel_case] = obj.delete(key)
+          end if obj.respond_to?(:keys)
+
+          obj
+        end
+      end
+
+      def parameterize_object(object)
+        return parameterize(object.to_h) if Sisense::API::Resource.descendants.include?(object.class)
+        return parameterize(object) if object.is_a?(Hash)
+        return object.map { |item| item.is_a?(String) ? item : parameterize_object(item) } if object.is_a?(Array)
       end
     end
   end

--- a/lib/sisense/api/client.rb
+++ b/lib/sisense/api/client.rb
@@ -110,7 +110,7 @@ module Sisense
           return object.map { |item| parameterize(item) } if object.is_a?(Array)
 
           obj.keys.each do |key|
-            obj[key] = parameterize_object(obj[key]) unless (obj[key].is_a?(String) or [true, false].include?(obj[key]))
+            obj[key] = parameterize_object(obj[key])
             obj[key.to_s.to_camel_case] = obj.delete(key)
           end if obj.respond_to?(:keys)
 
@@ -122,6 +122,8 @@ module Sisense
         return parameterize(object.to_h) if Sisense::API::Resource.descendants.include?(object.class)
         return parameterize(object) if object.is_a?(Hash)
         return object.map { |item| item.is_a?(String) ? item : parameterize_object(item) } if object.is_a?(Array)
+
+        object
       end
     end
   end

--- a/lib/sisense/api/client.rb
+++ b/lib/sisense/api/client.rb
@@ -111,7 +111,9 @@ module Sisense
           obj.keys.each do |key|
             obj[key] = parameterize_object(obj[key]) unless obj[key].is_a?(String)
             obj[key.to_s.to_camel_case] = obj.delete(key)
-          end
+          end if obj.respond_to?(:keys)
+
+          obj
         end
       end
 

--- a/lib/sisense/api/client.rb
+++ b/lib/sisense/api/client.rb
@@ -67,8 +67,7 @@ module Sisense
           request = VERB_MAP[method].new(encode_path(path, params), headers)
         else
           request = VERB_MAP[method].new(encode_path(path), headers)
-          binding.pry
-          request.body = parameterize(params).to_json
+          request.body = params.to_json
         end
         handle_response(http.request(request))
       end
@@ -103,27 +102,6 @@ module Sisense
 
       def headers
         @headers ||= { 'Authorization' => "Bearer #{Sisense.access_token}", 'Content-Type' => 'application/json' }
-      end
-
-      def parameterize(object)
-        object.tap do |obj|
-          return object.map { |item| parameterize(item) } if object.is_a?(Array)
-
-          obj.keys.each do |key|
-            obj[key] = parameterize_object(obj[key])
-            obj[key.to_s.to_camel_case] = obj.delete(key)
-          end if obj.respond_to?(:keys)
-
-          obj
-        end
-      end
-
-      def parameterize_object(object)
-        return parameterize(object.to_h) if Sisense::API::Resource.descendants.include?(object.class)
-        return parameterize(object) if object.is_a?(Hash)
-        return object.map { |item| item.is_a?(String) ? item : parameterize_object(item) } if object.is_a?(Array)
-
-        object
       end
     end
   end


### PR DESCRIPTION
Boolean values were previously getting converted to `null` on the output of the `parameterize()` method. I opened issue https://github.com/chronogolf/sisense/pull/7 and a fix was proposed. However I'm still unsure why we need `parameterize()`. Why not just do `params.to_json`?