### PR TITLE
Add links to GitHub so users can reach

### DIFF
--- a/sisense.gemspec
+++ b/sisense.gemspec
@@ -12,6 +12,13 @@ Gem::Specification.new do |spec|
   spec.description = "Light API client to communicate with Sisense API"
   spec.license = "MIT"
 
+  spec.homepage = 'https://github.com/chronogolf/sisense'
+  spec.metadata = {
+    'changelog_uri' => 'https://github.com/chronogolf/sisense/blob/master/CHANGELOG.md',
+    'source_code_uri' => 'https://github.com/chronogolf/sisense/',
+    'bug_tracker_uri' => 'https://github.com/chronogolf/sisense/issues',
+  }
+  
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end


### PR DESCRIPTION
Hi. 
When I found [this gem on RubyGems](https://rubygems.org/gems/sisense), I could not find links to GitHub repo.
I think links help users to find this GitHub repo and contribute.