### PR TITLE
Support Ruby 2.7 or higher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.6]
+        ruby: [2.7, 3.0, 3.1, 3.2]
 
     steps:
       - uses: actions/checkout@master
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.6]
+        ruby: [2.7, 3.0, 3.1, 3.2]
 
     steps:
       - uses: actions/checkout@master

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
     parallel (1.19.1)
     parser (2.7.1.2)
       ast (~> 2.4.0)
-    pry (0.13.1)
+    pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.5)
@@ -55,7 +55,7 @@ GEM
       rubocop (~> 0.82.0)
       rubocop-performance (~> 1.5.2)
     unicode-display_width (1.7.0)
-    vcr (5.1.0)
+    vcr (6.1.0)
     webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -75,4 +75,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.3
+   2.4.7

--- a/lib/sisense/api/client.rb
+++ b/lib/sisense/api/client.rb
@@ -91,11 +91,11 @@ module Sisense
         error_params = new_api_format_error_params || error_params
         case response.code
         when "404"
-          raise Sisense::API::NotFoundError, error_params
+          raise Sisense::API::NotFoundError.new(**error_params)
         when "422"
-          raise Sisense::API::UnprocessableEntityError, error_params
+          raise Sisense::API::UnprocessableEntityError.new(**error_params)
         else
-          raise Sisense::API::Error, error_params
+          raise Sisense::API::Error.new(**error_params)
         end
       end
 


### PR DESCRIPTION
I would like to add support for Ruby >= 2.7 and drop support for Ruby 2.6, which has reached EOL on 2022-04-12.